### PR TITLE
New methods for BITalinoState and possible fix to method stop()

### DIFF
--- a/api/src/main/java/info/plux/pluxapi/bitalino/BITalinoState.java
+++ b/api/src/main/java/info/plux/pluxapi/bitalino/BITalinoState.java
@@ -51,6 +51,10 @@ public class BITalinoState implements Parcelable {
         this.analog[pos] = value;
     }
 
+    public int[] getAnalogArray() {
+        return analog;
+    }
+
     public int getAnalogOutput() {
         return analogOutput;
     }
@@ -81,6 +85,10 @@ public class BITalinoState implements Parcelable {
 
     public void setDigital(final int pos, final int value) throws IndexOutOfBoundsException {
         this.digital[pos] = value;
+    }
+
+    public int[] getDigitalArray() {
+        return digital;
     }
 
     public String toString(){

--- a/api/src/main/java/info/plux/pluxapi/bitalino/bth/BTHCommunication.java
+++ b/api/src/main/java/info/plux/pluxapi/bitalino/bth/BTHCommunication.java
@@ -227,7 +227,7 @@ public class BTHCommunication extends BITalinoCommunication {
         } else {
             throw new BITalinoException(BITalinoErrorTypes.BT_DEVICE_NOT_CONNECTED);
         }
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
I added the methods `getAnalogArray()` ang `getDigitalArray()` to `BITalinoState`. These methods already existed in `BITalinoFrame`.
I also noticed that the method stop() of BITalinoCommunication returned `false` when the command was sent successfully, so I think that logic is inverted. I think I fixed it for the BTH communication.